### PR TITLE
fixed Citizens bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.netzkronehd</groupId>
     <artifactId>wgregionevents</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.7</version>
     <packaging>jar</packaging>
 
     <name>WGRegionEvents</name>
@@ -73,7 +73,10 @@
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>
-
+        <repository>
+            <id>everything</id>
+            <url>https://repo.citizensnpcs.co/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -87,9 +90,15 @@
         <dependency>
             <groupId>com.sk89q.worldguard</groupId>
             <artifactId>worldguard-bukkit</artifactId>
-            <version>7.0.4</version>
+            <version>LATEST</version>
             <scope>provided</scope>
         </dependency>
-
+        <dependency>
+            <groupId>net.citizensnpcs</groupId>
+            <artifactId>citizens-main</artifactId>
+            <version>2.0.29-SNAPSHOT</version>
+            <type>jar</type>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/de/netzkronehd/wgregionevents/WgRegionEvents.java
+++ b/src/main/java/de/netzkronehd/wgregionevents/WgRegionEvents.java
@@ -17,12 +17,14 @@ import java.util.UUID;
 public class WgRegionEvents extends JavaPlugin {
 
     private static WgRegionEvents instance;
+    public static boolean citizens = false;
     private HashMap<UUID, WgPlayer> playerCache;
     private SimpleWorldGuardAPI simpleWorldGuardAPI;
 
     @Override
     public void onLoad() {
         instance = this;
+        citizens = Bukkit.getPluginManager().getPlugin("Citizens") != null;
         playerCache = new HashMap<>();
         simpleWorldGuardAPI = new SimpleWorldGuardAPI();
     }

--- a/src/main/java/de/netzkronehd/wgregionevents/listener/WgRegionListener.java
+++ b/src/main/java/de/netzkronehd/wgregionevents/listener/WgRegionListener.java
@@ -4,6 +4,7 @@ import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import de.netzkronehd.wgregionevents.WgRegionEvents;
 import de.netzkronehd.wgregionevents.objects.WgPlayer;
 import de.netzkronehd.wgregionevents.events.*;
+import net.citizensnpcs.api.CitizensAPI;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -20,12 +21,14 @@ public class WgRegionListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onLogin(PlayerLoginEvent e) {
+        if(WgRegionEvents.citizens && CitizensAPI.getNPCRegistry().isNPC(e.getPlayer())) return;
         wg.getPlayerCache().remove(e.getPlayer().getUniqueId());
         wg.getPlayerCache().put(e.getPlayer().getUniqueId(), new WgPlayer(e.getPlayer()));
     }
 
     @EventHandler(priority = EventPriority.HIGH)
     public void onKick(PlayerKickEvent e) {
+        if(WgRegionEvents.citizens && CitizensAPI.getNPCRegistry().isNPC(e.getPlayer())) return;
         final WgPlayer wp = wg.getPlayer(e.getPlayer().getUniqueId());
         for (ProtectedRegion region : wp.getRegions()) {
             final RegionLeaveEvent leaveEvent = new RegionLeaveEvent(region, e.getPlayer(), MovementWay.DISCONNECT, e, e.getPlayer().getLocation(), e.getPlayer().getLocation());
@@ -39,6 +42,7 @@ public class WgRegionListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGH)
     public void onQuit(PlayerQuitEvent e) {
+        if(WgRegionEvents.citizens && CitizensAPI.getNPCRegistry().isNPC(e.getPlayer())) return;
         final WgPlayer wp = wg.getPlayer(e.getPlayer().getUniqueId());
         if(wp != null) {
             for (ProtectedRegion region : wp.getRegions()) {
@@ -55,18 +59,21 @@ public class WgRegionListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGH)
     public void onMove(PlayerMoveEvent e) {
+        if(WgRegionEvents.citizens && CitizensAPI.getNPCRegistry().isNPC(e.getPlayer())) return;
         final WgPlayer wp = wg.getPlayer(e.getPlayer().getUniqueId());
         e.setCancelled(wp.updateRegions(MovementWay.MOVE, e.getTo(), e.getFrom(), e));
     }
 
     @EventHandler(priority = EventPriority.HIGH)
     public void onMove(PlayerTeleportEvent e) {
+        if(WgRegionEvents.citizens && CitizensAPI.getNPCRegistry().isNPC(e.getPlayer())) return;
         final WgPlayer wp = wg.getPlayer(e.getPlayer().getUniqueId());
         e.setCancelled(wp.updateRegions(MovementWay.TELEPORT, e.getTo(), e.getFrom(), e));
     }
 
     @EventHandler(priority = EventPriority.HIGH)
     public void onJoin(PlayerJoinEvent e) {
+        if(WgRegionEvents.citizens && CitizensAPI.getNPCRegistry().isNPC(e.getPlayer())) return;
         final WgPlayer wp = wg.getPlayer(e.getPlayer().getUniqueId());
         wp.updateRegions(MovementWay.SPAWN, e.getPlayer().getLocation(), e.getPlayer().getLocation(), e);
 
@@ -74,6 +81,7 @@ public class WgRegionListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGH)
     public void onRespawn(PlayerRespawnEvent e) {
+        if(WgRegionEvents.citizens && CitizensAPI.getNPCRegistry().isNPC(e.getPlayer())) return;
         final WgPlayer wp = wg.getPlayer(e.getPlayer().getUniqueId());
         wp.updateRegions(MovementWay.SPAWN, e.getRespawnLocation(), e.getPlayer().getLocation(), e);
     }


### PR DESCRIPTION
```
[23:14:49 ERROR]: Could not pass event PlayerTeleportEvent to WGRegionEvents v1.7
java.lang.NullPointerException: Cannot invoke "de.netzkronehd.wgregionevents.objects.WgPlayer.updateRegions(de.netzkronehd.wgregionevents.events.MovementWay, org.bukkit.Location, org.bukkit.Location, org.bukkit.event.player.PlayerEvent)" because "wp" is null
        at de.netzkronehd.wgregionevents.listener.WgRegionListener.onMove(WgRegionListener.java:66) ~[WGRegionEvents.jar:?]
        at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor538.execute(Unknown Source) ~[?:?]
        at org.bukkit.plugin.EventExecutor.lambda$create$1(EventExecutor.java:69) ~[patched_1.17.1.jar:git-Paper-408]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[patched_1.17.1.jar:git-Paper-408]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[patched_1.17.1.jar:git-Paper-408]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:628) ~[patched_1.17.1.jar:git-Paper-408]
        at org.bukkit.craftbukkit.v1_17_R1.entity.CraftPlayer.teleport(CraftPlayer.java:1023) ~[patched_1.17.1.jar:git-Paper-408]
        at org.bukkit.craftbukkit.v1_17_R1.entity.CraftEntity.teleport(CraftEntity.java:556) ~[patched_1.17.1.jar:git-Paper-408]
        at net.citizensnpcs.npc.CitizensNPC.spawn(CitizensNPC.java:287) ~[Citizens.jar:?]
        at net.citizensnpcs.EventListen.spawn(EventListen.java:733) ~[Citizens.jar:?]
        at net.citizensnpcs.EventListen.respawnAllFromCoord(EventListen.java:708) ~[Citizens.jar:?]
        at net.citizensnpcs.EventListen.access$000(EventListen.java:109) ~[Citizens.jar:?]
        at net.citizensnpcs.EventListen$1.run(EventListen.java:158) ~[Citizens.jar:?]
        at org.bukkit.craftbukkit.v1_17_R1.scheduler.CraftTask.run(CraftTask.java:101) ~[patched_1.17.1.jar:git-Paper-408]
        at org.bukkit.craftbukkit.v1_17_R1.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:483) ~[patched_1.17.1.jar:git-Paper-408]
        at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1567) ~[patched_1.17.1.jar:git-Paper-408]
        at net.minecraft.server.dedicated.DedicatedServer.tickChildren(DedicatedServer.java:490) ~[patched_1.17.1.jar:git-Paper-408]
        at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1483) ~[patched_1.17.1.jar:git-Paper-408]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1282) ~[patched_1.17.1.jar:git-Paper-408]
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:319) ~[patched_1.17.1.jar:git-Paper-408]
        at java.lang.Thread.run(Thread.java:831) ~[?:?]
```
Dieser Fehler wurde auf einem Server mit dem Programm Citizens entdeckt. 
Er entstand durch den Versuch die UUID eines NPC’s, welcher durch Citizens die PlayerEvents triggered, über “.getUniqueId();” abzufragen. 
Da die WorldGuard Events nicht durch NPC’s getriggert werden sollen habe ich das Programm um diese Abfrage vor allen Events erweitert.