### PR TITLE
1.7.1 - Bugfixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.netzkronehd</groupId>
     <artifactId>wgregionevents</artifactId>
-    <version>1.7</version>
+    <version>1.7.1</version>
     <packaging>jar</packaging>
 
     <name>WGRegionEvents</name>

--- a/src/main/java/de/netzkronehd/wgregionevents/listener/WgRegionListener.java
+++ b/src/main/java/de/netzkronehd/wgregionevents/listener/WgRegionListener.java
@@ -61,21 +61,21 @@ public class WgRegionListener implements Listener {
     public void onMove(PlayerMoveEvent e) {
         if(WgRegionEvents.citizens && CitizensAPI.getNPCRegistry().isNPC(e.getPlayer())) return;
         final WgPlayer wp = wg.getPlayer(e.getPlayer().getUniqueId());
-        e.setCancelled(wp.updateRegions(MovementWay.MOVE, e.getTo(), e.getFrom(), e));
+        if(wp != null) e.setCancelled(wp.updateRegions(MovementWay.MOVE, e.getTo(), e.getFrom(), e));
     }
 
     @EventHandler(priority = EventPriority.HIGH)
     public void onMove(PlayerTeleportEvent e) {
         if(WgRegionEvents.citizens && CitizensAPI.getNPCRegistry().isNPC(e.getPlayer())) return;
         final WgPlayer wp = wg.getPlayer(e.getPlayer().getUniqueId());
-        e.setCancelled(wp.updateRegions(MovementWay.TELEPORT, e.getTo(), e.getFrom(), e));
+        if(wp != null) e.setCancelled(wp.updateRegions(MovementWay.TELEPORT, e.getTo(), e.getFrom(), e));
     }
 
     @EventHandler(priority = EventPriority.HIGH)
     public void onJoin(PlayerJoinEvent e) {
         if(WgRegionEvents.citizens && CitizensAPI.getNPCRegistry().isNPC(e.getPlayer())) return;
         final WgPlayer wp = wg.getPlayer(e.getPlayer().getUniqueId());
-        wp.updateRegions(MovementWay.SPAWN, e.getPlayer().getLocation(), e.getPlayer().getLocation(), e);
+        if(wp != null) wp.updateRegions(MovementWay.SPAWN, e.getPlayer().getLocation(), e.getPlayer().getLocation(), e);
 
     }
 
@@ -83,7 +83,7 @@ public class WgRegionListener implements Listener {
     public void onRespawn(PlayerRespawnEvent e) {
         if(WgRegionEvents.citizens && CitizensAPI.getNPCRegistry().isNPC(e.getPlayer())) return;
         final WgPlayer wp = wg.getPlayer(e.getPlayer().getUniqueId());
-        wp.updateRegions(MovementWay.SPAWN, e.getRespawnLocation(), e.getPlayer().getLocation(), e);
+        if(wp != null) wp.updateRegions(MovementWay.SPAWN, e.getRespawnLocation(), e.getPlayer().getLocation(), e);
     }
 
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,3 +4,5 @@ main: de.netzkronehd.wgregionevents.WgRegionEvents
 author: NetzkroneHD
 api-version: 1.13
 depend: [WorldGuard]
+softdepend:
+  - Citizens


### PR DESCRIPTION
+ Citizens wurde als soft-depend hinzugefügt, um Warnungen in der Konsole zu vermeiden.
`[XX:XX:XX] [Server thread/WARN]: [WGRegionEvents] Loaded class net.citizensnpcs.api.CitizensAPI from Citizens v2.0.29-SNAPSHOT (build 2458) which is not a depend, softdepend or loadbefore of this plugin.`
+ Zusätzliche !=N Abfrage um Fehler von Dritten, die Aktivitäten beenden, bevor dieses Programm das Event zu Ende ausführen kann
```
[XX:XX:XX ERROR]: Could not pass event PlayerTeleportEvent to WGRegionEvents v1.7
java.lang.NullPointerException: Cannot invoke "de.netzkronehd.wgregionevents.objects.WgPlayer.updateRegions(de.netzkronehd.wgregionevents.events.MovementWay, org.bukkit.Location, org.bukkit.Location, org.bukkit.event.player.PlayerEvent)" because "wp" is null
        at de.netzkronehd.wgregionevents.listener.WgRegionListener.onMove(WgRegionListener.java:71) ~[wgregionevents-1.7.jar:?]
        at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor634.execute(Unknown Source) ~[?:?]
        at org.bukkit.plugin.EventExecutor.lambda$create$1(EventExecutor.java:69) ~[patched_1.17.1.jar:git-Paper-408]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[patched_1.17.1.jar:git-Paper-408]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[patched_1.17.1.jar:git-Paper-408]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:628) ~[patched_1.17.1.jar:git-Paper-408]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.a(ServerGamePacketListenerImpl.java:1605) ~[app:?]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.teleport(ServerGamePacketListenerImpl.java:1568) ~[app:?]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.dismount(ServerGamePacketListenerImpl.java:1564) ~[app:?]
        at net.minecraft.server.level.ServerPlayer.dismountTo(ServerPlayer.java:1415) ~[app:?]
        at net.minecraft.world.entity.LivingEntity.dismountVehicle(LivingEntity.java:2558) ~[app:?]
        at net.minecraft.world.entity.LivingEntity.stopRiding(LivingEntity.java:3390) ~[app:?]
        at net.minecraft.world.entity.player.Player.stopRiding(Player.java:1123) ~[app:?]
        at net.minecraft.server.level.ServerPlayer.stopRiding(ServerPlayer.java:1402) ~[app:?]
        at net.minecraft.server.level.ServerPlayer.stopRiding(ServerPlayer.java:1397) ~[app:?]
        at org.bukkit.craftbukkit.v1_17_R1.entity.CraftEntity.removePassenger(CraftEntity.java:738) ~[patched_1.17.1.jar:git-Paper-408]
        at XX.XXXXXXX.XXXXXXX.listeners.PlayerQuit.onQuit(PlayerQuit.java:33) ~[XXXXXXXX-X.X.X.jar:?]
        at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor161.execute(Unknown Source) ~[?:?]
        at org.bukkit.plugin.EventExecutor.lambda$create$1(EventExecutor.java:69) ~[patched_1.17.1.jar:git-Paper-408]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[patched_1.17.1.jar:git-Paper-408]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[patched_1.17.1.jar:git-Paper-408]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:628) ~[patched_1.17.1.jar:git-Paper-408]
        at net.minecraft.server.players.PlayerList.disconnect(PlayerList.java:607) ~[patched_1.17.1.jar:git-Paper-408]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.onDisconnect(ServerGamePacketListenerImpl.java:1967) ~[app:?]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.disconnect(ServerGamePacketListenerImpl.java:460) ~[app:?]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.disconnect(ServerGamePacketListenerImpl.java:423) ~[app:?]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.tick(ServerGamePacketListenerImpl.java:323) ~[app:?]
        at net.minecraft.network.Connection.tick(Connection.java:555) ~[app:?]
        at net.minecraft.server.network.ServerConnectionListener.tick(ServerConnectionListener.java:201) ~[app:?]
        at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1656) ~[patched_1.17.1.jar:git-Paper-408]
        at net.minecraft.server.dedicated.DedicatedServer.tickChildren(DedicatedServer.java:490) ~[patched_1.17.1.jar:git-Paper-408]
        at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1483) ~[patched_1.17.1.jar:git-Paper-408]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1282) ~[patched_1.17.1.jar:git-Paper-408]
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:319) ~[patched_1.17.1.jar:git-Paper-408]
        at java.lang.Thread.run(Thread.java:831) ~[?:?]
```
+ Minor Versionserhöhung